### PR TITLE
fix(void-fn): Handle void fn params

### DIFF
--- a/packages/clangffi/src/lib/tsgen/index.ts
+++ b/packages/clangffi/src/lib/tsgen/index.ts
@@ -216,14 +216,15 @@ export class TsGen implements ISourceGenerator {
 
     const typeClass = decl.typeClass;
 
-    if (
-      typeClass.isFunctionType &&
-      typeClass.returnType &&
-      typeClass.paramTypes
-    ) {
-      const params = typeClass.paramTypes
-        .map((p) => resolveType(p, this.refResolver))
-        .join(",");
+    if (typeClass.isFunctionType && typeClass.returnType) {
+      let params = "";
+
+      // if we actually have params, overwrite the empty string
+      if (typeClass.paramTypes && typeClass.paramTypes.length > 0) {
+        params = typeClass.paramTypes
+          .map((p) => resolveType(p, this.refResolver))
+          .join(",");
+      }
 
       this.fnBuilder.appendLine(
         `"${name}": [${resolveType(

--- a/packages/clangffi/src/lib/tsgen/resolve.ts
+++ b/packages/clangffi/src/lib/tsgen/resolve.ts
@@ -88,10 +88,14 @@ export class TSResolver implements ITypeNameResolver {
     );
 
     // ts needs names before types so generate that signature
-    const sig = params
-      .split(",")
-      .map((p, i) => `arg${i}: ${p}`.trim())
-      .join(", ");
+    // if `params.length` is zero we have no params so just use an empty string
+    const sig =
+      params.length == 0
+        ? ""
+        : params
+            .split(",")
+            .map((p, i) => `arg${i}: ${p}`.trim())
+            .join(", ");
 
     return `(${sig}) => ${ret}`;
   }
@@ -245,13 +249,15 @@ export function resolveType(type: Type, resolver: ITypeNameResolver): string {
     );
   }
   // function
-  else if (type.isFunctionType && type.paramTypes && type.returnType) {
+  else if (type.isFunctionType && type.returnType) {
     resolveLog(`${type.name} is fn`);
 
-    // resolve all the params first
-    const params = type.paramTypes
-      .map((p) => resolveType(p, resolver))
-      .join(", ");
+    let params = "";
+
+    // if we actually have params, overwrite the empty string
+    if (type.paramTypes && type.paramTypes.length > 0) {
+      params = type.paramTypes.map((p) => resolveType(p, resolver)).join(", ");
+    }
 
     resolveLog(`${type.name} resolved params`);
 


### PR DESCRIPTION
fixes #16 - better handling for situations like:


```
typedef void (*MyFunctionPointer)(void);
```
