### PR TITLE
feat(attributed-type): support attributed fns

### DIFF
--- a/packages/clangffi/src/lib/tsgen/index.ts
+++ b/packages/clangffi/src/lib/tsgen/index.ts
@@ -214,7 +214,15 @@ export class TsGen implements ISourceGenerator {
     const name = resolveName(decl);
     log(`openFunction(${name}): begin`);
 
-    const typeClass = decl.typeClass;
+    let typeClass = decl.typeClass;
+
+    // if it's an attributed type we should just access the internal type
+    //
+    // TODO(bengreenier): should we do this for all types? docs on attributed types are weak
+    // i am not sure if this only occurs for function types or if it may occur for other types
+    if (typeClass.isAttributedType && typeClass.modifiedType) {
+      typeClass = typeClass.modifiedType;
+    }
 
     if (
       typeClass.isFunctionType &&

--- a/packages/libclang-bindings/src/models/type.ts
+++ b/packages/libclang-bindings/src/models/type.ts
@@ -31,6 +31,13 @@ export class Type implements INativeHandle<CXType> {
     return this.spelling;
   }
 
+  get isAttributedType(): boolean {
+    return this.kind == CXTypeKind.CXType_Attributed;
+  }
+  get modifiedType(): Type | undefined {
+    return new Type(lib.clang_Type_getModifiedType(this.type));
+  }
+
   get isCanonical(): boolean {
     return this.kind != CXTypeKind.CXType_Elaborated;
   }


### PR DESCRIPTION
quick fixes #22 - allowing us to walk into the modified type of an attributed type.

Adds to `Type` API