### PR TITLE
feat: --clean-enum-constants flag

### DIFF
--- a/packages/clangffi/src/bin/clangffi.ts
+++ b/packages/clangffi/src/bin/clangffi.ts
@@ -72,14 +72,12 @@ const args = yargs(hideBin(process.argv))
     },
     crlf: {
       type: "boolean",
-      describe:
-        "Flag indicating if `crlf` line endings should be used instead of `lf`.",
+      describe: "Use `crlf` line endings instead of `lf`.",
       default: false,
     },
     prettier: {
       type: "boolean",
-      describe:
-        "Flag indicating if `prettier` will be run against the bindings before output.",
+      describe: "Run `prettier` against the bindings before output.",
       default: true,
     },
     "lib-path": {
@@ -90,7 +88,7 @@ const args = yargs(hideBin(process.argv))
     "default-symbols": {
       type: "boolean",
       describe:
-        "Flag indicating if symbols in the `input` file will be automatically included in the bindings.",
+        "Automatically include symbols in the `input` file in the bindings.",
       default: true,
     },
     include: {
@@ -120,6 +118,12 @@ const args = yargs(hideBin(process.argv))
       describe:
         "Custom native to node symbol mappings that override the default.",
       default: [] as string[],
+    },
+    "clean-enum-constants": {
+      type: "boolean",
+      describe:
+        "Convert constant names like `ENUM_NAME_FOO_BAR` to `FooBar` in enums.",
+      default: true,
     },
   })
   .example([
@@ -270,6 +274,7 @@ if (!(args instanceof Promise)) {
           return { selector: parse(key), replacement: val };
         }),
       },
+      cleanEnumConstants: args.cleanEnumConstants,
     }),
   }).parseAndGenerate();
 } else {

--- a/packages/clangffi/src/lib/util.ts
+++ b/packages/clangffi/src/lib/util.ts
@@ -59,3 +59,14 @@ export function resolveName(decl: Decl): string | undefined {
 export function formatPath(str: string): string {
   return str.replace(/\\/g, "/");
 }
+
+/**
+ * Transform a SNAKE_CASE string to a PascalCase string.
+ * @param str string to transform
+ */
+export function snakeToPascalCase(str: string): string {
+  return str.replace(
+    /([^_])([^_]*)(_|$)/gi,
+    (_, first, rest) => first + rest.toLowerCase()
+  );
+}


### PR DESCRIPTION
Making a draft for this, because it's finished in theory but I can't test it 😅 

I get a crash like so:
```
PS C:\code\node-clangffi> cat hi.h
enum MyEnum {
    MY_ENUM_FOO = 1,
    MY_ENUM_BAR = 2,
};

PS C:\code\node-clangffi> npm run clangffi --  --clean-enum-constants -i hi.h -o hi.ts

> node-clangffi-lerna-workspace@1.0.0 clangffi
> node packages/clangffi/dist/bin/clangffi.js "--clean-enum-constants" "-i" "hi.h" "-o" "hi.ts"

Invalid CXChildVisitResult!
UNREACHABLE executed at C:\src\llvm_package_1400-rc2\llvm-project\clang\tools\libclang\CIndex.cpp:236!
```
on every invocation of clangffi. Have you ever seen this @bengreenier?