### PR TITLE
fix: Restore ".js" in relative imports

### DIFF
--- a/packages/clangffi/package.json
+++ b/packages/clangffi/package.json
@@ -13,6 +13,9 @@
     "test": "jest"
   },
   "jest": {
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1"
+    },
     "transformIgnorePatterns": [
       "<rootDir>/node_modules/(?!matcher)"
     ],

--- a/packages/clangffi/src/bin/clangffi.test.ts
+++ b/packages/clangffi/src/bin/clangffi.test.ts
@@ -1,5 +1,5 @@
 import { Language, loadLibClang } from "libclang-bindings";
-import { Parser } from "../lib";
+import { Parser } from "../lib/parser";
 import { TsGen } from "../lib/tsgen";
 import { LineEndings } from "../lib/types";
 import fs from "node:fs";

--- a/packages/clangffi/src/bin/clangffi.ts
+++ b/packages/clangffi/src/bin/clangffi.ts
@@ -4,13 +4,13 @@ import { fileURLToPath } from "node:url";
 import fs from "node:fs";
 import path from "node:path";
 import { Language, loadLibClang } from "libclang-bindings";
-import { Parser } from "../lib/index";
-import { TsGen } from "../lib/tsgen/index";
-import { LineEndings } from "../lib/types";
+import { Parser } from "../lib/index.js";
+import { TsGen } from "../lib/tsgen/index.js";
+import { LineEndings } from "../lib/types.js";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import debug from "debug";
-import { parse } from "../lib/selector";
+import { parse } from "../lib/selector.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const log = debug("clangffi");

--- a/packages/clangffi/src/lib/index.ts
+++ b/packages/clangffi/src/lib/index.ts
@@ -1,3 +1,3 @@
-import { Parser, ParserOptions } from "./parser";
+import { Parser, ParserOptions } from "./parser.js";
 
 export { Parser, ParserOptions };

--- a/packages/clangffi/src/lib/parser.ts
+++ b/packages/clangffi/src/lib/parser.ts
@@ -20,9 +20,9 @@ import {
   TypedefDecl,
   CXTypeKind,
 } from "libclang-bindings";
-import { ISourceGenerator } from "./types";
-import { formatPath, resolveName } from "./util";
-import { matches, SelectorData } from "./selector";
+import { ISourceGenerator } from "./types.js";
+import { formatPath, resolveName } from "./util.js";
+import { matches, SelectorData } from "./selector.js";
 
 const log = debug("clangffi:parser");
 

--- a/packages/clangffi/src/lib/string-builder.ts
+++ b/packages/clangffi/src/lib/string-builder.ts
@@ -1,4 +1,4 @@
-import { LineEndings } from "./types";
+import { LineEndings } from "./types.js";
 
 export class StringBuilder {
   private buffer: string[] = [];

--- a/packages/clangffi/src/lib/tsgen/index.ts
+++ b/packages/clangffi/src/lib/tsgen/index.ts
@@ -13,16 +13,16 @@ import {
   TypedefDecl,
   UnionDecl,
 } from "libclang-bindings";
-import { StringBuilder } from "../string-builder";
+import { StringBuilder } from "../string-builder.js";
 import {
   ISourceGenerator,
   ITypeNameResolver,
   LineEndings,
   SymbolReplacementSpec,
-} from "../types";
-import { RefResolver, resolveType, TSResolver } from "./resolve";
-import { resolveName, snakeToPascalCase } from "../util";
-import { matches } from "../selector";
+} from "../types.js";
+import { RefResolver, resolveType, TSResolver } from "./resolve.js";
+import { resolveName, snakeToPascalCase } from "../util.js";
+import { matches } from "../selector.js";
 
 const log = debug("clangffi:tsgen");
 

--- a/packages/clangffi/src/lib/tsgen/resolve.ts
+++ b/packages/clangffi/src/lib/tsgen/resolve.ts
@@ -1,8 +1,8 @@
 import debug from "debug";
 import { Type } from "libclang-bindings";
-import { StringBuilder } from "../string-builder";
-import { ITypeNameResolver, LineEndings } from "../types";
-import { simpleDesugar } from "../util";
+import { StringBuilder } from "../string-builder.js";
+import { ITypeNameResolver, LineEndings } from "../types.js";
+import { simpleDesugar } from "../util.js";
 
 /**
  * log for resolving ref types

--- a/packages/clangffi/src/lib/types.ts
+++ b/packages/clangffi/src/lib/types.ts
@@ -8,7 +8,7 @@ import {
   FunctionDecl,
   ParamDecl,
 } from "libclang-bindings";
-import { SelectorData } from "./selector";
+import { SelectorData } from "./selector.js";
 
 export interface ISourceGenerator {
   open(outputPath: string): void;


### PR DESCRIPTION
I totally did a "[Chesterton's fence](https://www.goodreads.com/quotes/833466-in-the-matter-of-reforming-things-as-distinct-from-deforming)"! These are apparently required for ES modules. https://www.typescriptlang.org/docs/handbook/esm-node.html#type-in-packagejson-and-new-extensions