### PR TITLE
fix(struct-alias): Support struct typedef aliasing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "lerna workspace for clangffi, libclang-bindings tools",
   "scripts": {
     "clangffi": "node packages/clangffi/dist/bin/clangffi.js",
-    "generate-dogfood": "npm run clangffi -- -i vendor/llvm-project/clang/include/clang-c/Index.h -I vendor/llvm-project/clang/include/ -o packages/libclang-bindings/src/libclang.ts --include *time*_t --include-file vendor/llvm-project/clang/include/clang-c/",
+    "generate-dogfood": "npm run clangffi -- --clean-enum-constants=false -i vendor/llvm-project/clang/include/clang-c/Index.h -I vendor/llvm-project/clang/include/ -o packages/libclang-bindings/src/libclang.ts --include *time*_t --include-file vendor/llvm-project/clang/include/clang-c/",
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build --stream",
     "test": "lerna run test --stream"
@@ -14,5 +14,8 @@
   "license": "MIT",
   "devDependencies": {
     "lerna": "^4.0.0"
+  },
+  "volta": {
+    "node": "17.9.1"
   }
 }

--- a/packages/clangffi/README.md
+++ b/packages/clangffi/README.md
@@ -45,6 +45,7 @@ Options:
       --include-file         File paths to explicitly include symbols from, in addition to the default. If a directory path is given symbols from all files in that directory will be included.                                         [array] [default: []]
       --exclude              Symbols to explicitly exclude from the bindings. Overrides `include` if there is a conflict.                                                                                                               [array] [default: []]
       --hard-remap, --remap  Custom native to node symbol mappings that override the default.                                                                                                                                           [array] [default: []]
+      --clean-enum-constants  Convert constant names like `ENUM_NAME_FOO_BAR` to `FooBar` in enums.                                                                                                                                 [boolean] [default: true]
       --help                 Show help                                                                                                                                                                                                              [boolean]
 
 Examples:

--- a/packages/clangffi/src/lib/tsgen/resolve.ts
+++ b/packages/clangffi/src/lib/tsgen/resolve.ts
@@ -244,6 +244,13 @@ export function resolveType(type: Type, resolver: ITypeNameResolver): string {
     // here we pull off the struct sugar before creating the resolved type
     sb.append(resolver.createStruct(type.name.substring("struct ".length)));
   }
+  // union (not just all records, only those that are unions)
+  else if (type.isRecordType && type.name.startsWith("union ")) {
+    resolveLog(`${type.name} is union`);
+
+    // here we pull off the union sugar before creating the resolved type
+    sb.append(resolver.createUnion(type.name.substring("union ".length)));
+  }
   // array
   else if (type.isArrayType && type.elementType) {
     resolveLog(`${type.name} is array`);

--- a/packages/clangffi/src/lib/util.ts
+++ b/packages/clangffi/src/lib/util.ts
@@ -39,6 +39,11 @@ export function simpleDesugar(type: Type) {
     desugarLog(`removed enum prefix: '${desugared}'`);
   }
 
+  if (desugared.startsWith("union ")) {
+    desugared = desugared.replace("union ", "");
+    desugarLog(`removed union prefix: '${desugared}'`);
+  }
+
   return desugared;
 }
 

--- a/packages/clangffi/src/lib/util.ts
+++ b/packages/clangffi/src/lib/util.ts
@@ -29,6 +29,16 @@ export function simpleDesugar(type: Type) {
     desugarLog(`removed const: '${desugared}'`);
   }
 
+  if (desugared.startsWith("struct ")) {
+    desugared = desugared.replace("struct ", "");
+    desugarLog(`removed struct prefix: '${desugared}'`);
+  }
+
+  if (desugared.startsWith("enum ")) {
+    desugared = desugared.replace("enum ", "");
+    desugarLog(`removed enum prefix: '${desugared}'`);
+  }
+
   return desugared;
 }
 

--- a/packages/libclang-bindings/package-lock.json
+++ b/packages/libclang-bindings/package-lock.json
@@ -12,7 +12,8 @@
         "ffi-napi": "^4.0.3",
         "ref-array-di": "^1.2.2",
         "ref-napi": "^3.0.3",
-        "ref-struct-di": "^1.1.1"
+        "ref-struct-di": "^1.1.1",
+        "ref-union-di": "^1.0.1"
       },
       "devDependencies": {
         "@babel/core": "^7.16.7",
@@ -24,12 +25,13 @@
         "@types/ref-array-di": "^1.2.3",
         "@types/ref-napi": "^3.0.4",
         "@types/ref-struct-di": "^1.1.5",
+        "@types/ref-union-di": "^1.0.3",
         "babel-jest": "^27.4.5",
         "jest": "^27.4.5",
         "typescript": "^4.5.4"
       },
       "engines": {
-        "node": "^17.x"
+        "node": ">=17.x"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2177,6 +2179,15 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@types/ref-struct-di/-/ref-struct-di-1.1.5.tgz",
       "integrity": "sha512-8pPFcSyw+jI7tvUC5Du9NqOhZeKOvt2LxvPN+9aKnXAu68URpWYrwY99LaraH58+XQIYWbD8tw3SH+h4/1A5vA==",
+      "dev": true,
+      "dependencies": {
+        "@types/ref-napi": "*"
+      }
+    },
+    "node_modules/@types/ref-union-di": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ref-union-di/-/ref-union-di-1.0.3.tgz",
+      "integrity": "sha512-eonV03cHemB4w9i5U9oi5DLplpW2gK4pTJPdBAedg8RI/QViJXSnNprBriJ03eb/4qx06gPVGZ3SA2EdGuFGjw==",
       "dev": true,
       "dependencies": {
         "@types/ref-napi": "*"
@@ -4851,6 +4862,22 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/ref-union-di": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ref-union-di/-/ref-union-di-1.0.1.tgz",
+      "integrity": "sha512-JWSF2BwNVtCgmEfoDGMh8S1KO07oq+T8L7cBHwcsmQmeXDZd9JNlrxU+ebSHs+jsf0qrqFFWXMCmj94Tcl26TA==",
+      "dependencies": {
+        "debug": "^3.1.0"
+      }
+    },
+    "node_modules/ref-union-di/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -7198,6 +7225,15 @@
         "@types/ref-napi": "*"
       }
     },
+    "@types/ref-union-di": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ref-union-di/-/ref-union-di-1.0.3.tgz",
+      "integrity": "sha512-eonV03cHemB4w9i5U9oi5DLplpW2gK4pTJPdBAedg8RI/QViJXSnNprBriJ03eb/4qx06gPVGZ3SA2EdGuFGjw==",
+      "dev": true,
+      "requires": {
+        "@types/ref-napi": "*"
+      }
+    },
     "@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
@@ -9261,6 +9297,24 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.1.tgz",
       "integrity": "sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g==",
+      "requires": {
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "ref-union-di": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ref-union-di/-/ref-union-di-1.0.1.tgz",
+      "integrity": "sha512-JWSF2BwNVtCgmEfoDGMh8S1KO07oq+T8L7cBHwcsmQmeXDZd9JNlrxU+ebSHs+jsf0qrqFFWXMCmj94Tcl26TA==",
       "requires": {
         "debug": "^3.1.0"
       },

--- a/packages/libclang-bindings/package.json
+++ b/packages/libclang-bindings/package.json
@@ -34,6 +34,7 @@
     "@types/ref-array-di": "^1.2.3",
     "@types/ref-napi": "^3.0.4",
     "@types/ref-struct-di": "^1.1.5",
+    "@types/ref-union-di": "^1.0.3",
     "babel-jest": "^27.4.5",
     "jest": "^27.4.5",
     "typescript": "^4.5.4"
@@ -42,7 +43,8 @@
     "ffi-napi": "^4.0.3",
     "ref-array-di": "^1.2.2",
     "ref-napi": "^3.0.3",
-    "ref-struct-di": "^1.1.1"
+    "ref-struct-di": "^1.1.1",
+    "ref-union-di": "^1.0.1"
   },
   "engines": {
     "node": ">=17.x"

--- a/packages/libclang-bindings/src/libclang.ts
+++ b/packages/libclang-bindings/src/libclang.ts
@@ -2,8 +2,9 @@ import ffi from "ffi-napi";
 import ref, { Pointer as TypedPointer, UnderlyingType } from "ref-napi";
 import refStructDi, { StructObject } from "ref-struct-di";
 import refArrayDi, { TypedArray } from "ref-array-di";
-
+import refUnionDi from "ref-union-di";
 const Struct = refStructDi(ref);
+const Union = refUnionDi(ref);
 const ArrayType = refArrayDi(ref);
 const Pointer = ref.refType;
 export type __time32_t = number;


### PR DESCRIPTION
This adds support for

```
typedef struct MyStruct { int fieldA; } MyStruct;
typedef struct MyStruct AliasToMyStruct;
````

such that `AliasToMyStruct` is parsed properly. 

Previously, we'd relied on elaborated type parsing for typedefs assuming that we'd process all necessary children. However, given that `struct` is included in the alias definition, it incorrectly triggers that assumption and is then never processed.

This fix compares a `simpleDesugar`-ed type name with the current cursor `symbolName` and if they don't align, identifies it as the alias case, and generates the alias as expected (e.g. `type AliasToMyStruct = MyStruct`).